### PR TITLE
$$value$$ Not converted to Model

### DIFF
--- a/src/angular-schema-form-range-slider.html
+++ b/src/angular-schema-form-range-slider.html
@@ -5,6 +5,7 @@
               class="input-group-addon"
               ng-bind-html="form.fieldAddonLeft"></span>
         <rzslider ng-show="form.key"
+                   sf-field-model="replaceAll"
                    class="{{form.fieldHtmlClass}}"
                    ng-disabled="form.readonly"
                    rz-slider-options="form.options"


### PR DESCRIPTION
With the special value replaceAll the ngModel builder will instead loop over every attribute on the element and do a string replacement of "$$value$$" with the proper model value.

https://github.com/json-schema-form/angular-schema-form/blob/development/docs/extending.md#the-template